### PR TITLE
Updating deprecated methods

### DIFF
--- a/sites/dsp/bid.js
+++ b/sites/dsp/bid.js
@@ -21,7 +21,7 @@ function generateBid(interestGroup, auctionSignals, perBuyerSignals, trustedBidd
     ad: {
       adName: testAd?.metadata?.adName,
     },
-    render: testAd?.renderUrl,
+    render: testAd?.renderURL,
   };
 }
 

--- a/sites/dsp/join-ad-interest-group.js
+++ b/sites/dsp/join-ad-interest-group.js
@@ -23,7 +23,7 @@ const joinInterestGroup = async (dspUrl) => {
     biddingLogicUrl: `${dspUrl}/bid.js`,
     ads: [
       {
-        renderUrl: `${dspUrl}/ads/default-ad.html`,
+        renderURL: `${dspUrl}/ads/default-ad.html`,
         metadata: {
           adName: 'default-ad',
         },

--- a/sites/ssp/run-auction.js
+++ b/sites/ssp/run-auction.js
@@ -18,7 +18,7 @@ const runAuction = async (sspUrl, dspUrl) => {
 
   const auctionConfig = {
     seller: `${sspUrl}`,
-    decisionLogicUrl: `${sspUrl}/decision-logic.js`,
+    decisionLogicURL: `${sspUrl}/decision-logic.js`,
     interestGroupBuyers: [dspUrl],
     auctionSignals: { isControversial: true },
     sellerSignals: { key: 'value' },


### PR DESCRIPTION
## Description
This pull request updates some deprecated properties pointed out by Chrome:
- `renderUrl` to `renderURL`
- `decisionLogicUrl` to `decisionLogicURL`

<img width="1911" alt="Screenshot 2024-08-02 at 12 35 00" src="https://github.com/user-attachments/assets/fe156765-682d-45e0-b2e7-c1d62b1ede00">
